### PR TITLE
Typo and clarification for shadow_dom cross-browser support in Ch7

### DIFF
--- a/Chapter_07/README.md
+++ b/Chapter_07/README.md
@@ -307,10 +307,10 @@ dependencies:
   shadow_dom: any
 ```
 
-And include the script tag:
+And include the script tag at the top of the head section:
 
 ```
-<script src="packages/shadow_dom/shadow_dom.debug.js"></script>
+<script src="packages/shadow_dom/shadow_dom.min.js"></script>
 ```
 
 or the debug version:


### PR DESCRIPTION
The debug version was specified twice instead of minified. Also specified that the script should be located at the top of the html head.
