### PR TITLE
avoid duplicate ids in ng-repeated span (category-filter)

### DIFF
--- a/Chapter_05/web/index.html
+++ b/Chapter_05/web/index.html
@@ -21,11 +21,12 @@
                  value=" "></input>
         </div>
         <div>
-          <label for="category-filter">Filter recipes by category</label>
-          <span  id="category-filter" ng-repeat="category in ctrl.categories">
-            <input type="checkbox"
-               ng-model="ctrl.categoryFilterMap[category]">{{category}}
-          </span>
+          <label>Filter recipes by category
+            <span ng-repeat="category in ctrl.categories">
+              <input type="checkbox"
+                 ng-model="ctrl.categoryFilterMap[category]">{{category}}
+            </span>
+          </label>
         </div>
         <input type="button" value="Clear Filters" ng-click="ctrl.clearFilters()">
       </div>


### PR DESCRIPTION
Eliminated the need for the span id by putting the span inside the label element rather than using the label for attribute. (I can also updated the associated wiki page if this PR goes in.)
