### PR TITLE
unnecessary test for null removed from CategoryFilter.call (Chap. 5-7)

### DIFF
--- a/Chapter_05/lib/filter/category_filter.dart
+++ b/Chapter_05/lib/filter/category_filter.dart
@@ -5,7 +5,7 @@ import 'package:angular/angular.dart';
 @NgFilter(name: 'categoryfilter')
 class CategoryFilter {
   call(recipeList, filterMap) {
-    if (recipeList is List && filterMap != null && filterMap is Map) {
+    if (recipeList is List && filterMap is Map) {
       // If there is nothing checked, treat it as "everything is checked"
       bool nothingChecked = filterMap.values.every((isChecked) => !isChecked);
       if (nothingChecked) {

--- a/Chapter_06/lib/filter/category_filter.dart
+++ b/Chapter_06/lib/filter/category_filter.dart
@@ -5,7 +5,7 @@ import 'package:angular/angular.dart';
 @NgFilter(name: 'categoryfilter')
 class CategoryFilter {
   call(recipeList, filterMap) {
-    if (recipeList is List && filterMap != null && filterMap is Map) {
+    if (recipeList is List && filterMap is Map) {
       // If there is nothing checked, treat it as "everything is checked"
       bool nothingChecked = filterMap.values.every((isChecked) => !isChecked);
       if (nothingChecked) {

--- a/Chapter_07/lib/filter/category_filter.dart
+++ b/Chapter_07/lib/filter/category_filter.dart
@@ -5,7 +5,7 @@ import 'package:angular/angular.dart';
 @NgFilter(name: 'categoryfilter')
 class CategoryFilter {
   call(recipeList, filterMap) {
-    if (recipeList is List && filterMap != null && filterMap is Map) {
+    if (recipeList is List && filterMap is Map) {
       // If there is nothing checked, treat it as "everything is checked"
       bool nothingChecked = filterMap.values.every((isChecked) => !isChecked);
       if (nothingChecked) {


### PR DESCRIPTION
In CategoryFilter.call, there is no need to test for (filterMap != null) immediately before the conjunct (filterMap is Map) since (null is T) is always false. Updated this in Chapters 5 to 7.  I can also do the updates to the wiki if this PR goes in.
