### PR TITLE
Remove value attribute of text input having ng-model (Ch.5)

### DIFF
--- a/Chapter_05/web/index.html
+++ b/Chapter_05/web/index.html
@@ -17,8 +17,7 @@
         <div>
           <label for="name-filter">Filter recipes by name</label>
           <input id="name-filter" type="text" 
-                 ng-model="ctrl.nameFilterString"
-                 value=" "></input>
+                 ng-model="ctrl.nameFilterString">
         </div>
         <div>
           <label for="category-filter">Filter recipes by category</label>


### PR DESCRIPTION
- Removed the `value` attribute: given that the `“name-filter”` text input is bound to the `ctrl.nameFilterString` model, the presence of the input `value` attribute seems at best useless, but is more likely to be confusing to beginners. 
- Also removed input end tag (since [input is an empty / void element](http://stackoverflow.com/questions/13232121/closing-html-input-tag-issue)).
