### PR TITLE
fix(recipe): follow dart:convert.JsonCodec JSON encoding convention

### DIFF
--- a/Chapter_05/lib/recipe.dart
+++ b/Chapter_05/lib/recipe.dart
@@ -9,7 +9,8 @@ class Recipe {
   int rating;
   String imgUrl;
 
-  Recipe(this.id, this.name, this.category, this.ingredients, this.directions, this.rating, this.imgUrl);
+  Recipe(this.id, this.name, this.category, this.ingredients, this.directions,
+      this.rating, this.imgUrl);
 
   Map<String, dynamic> toJson() => <String, dynamic>{
     "id": id,

--- a/Chapter_05/lib/recipe.dart
+++ b/Chapter_05/lib/recipe.dart
@@ -22,7 +22,7 @@ class Recipe {
     "imgUrl": imgUrl
   };
 
-  factory Recipe.fromJsonMap(Map<String, dynamic> json) => new Recipe(json['id'], json['name'],
-      json['category'], json['ingredients'], json['directions'], json['rating'],
-      json['imgUrl']);
+  factory Recipe.fromJsonMap(Map<String, dynamic> json) => new Recipe(json['id'],
+      json['name'], json['category'], json['ingredients'], json['directions'],
+      json['rating'], json['imgUrl']);
 }

--- a/Chapter_05/lib/recipe.dart
+++ b/Chapter_05/lib/recipe.dart
@@ -1,7 +1,5 @@
 library recipe;
 
-import 'dart:convert';
-
 class Recipe {
   String id;
   String name;
@@ -11,25 +9,19 @@ class Recipe {
   int rating;
   String imgUrl;
 
-  Recipe(this.id, this.name, this.category, this.ingredients, this.directions,
-      this.rating, this.imgUrl);
+  Recipe(this.id, this.name, this.category, this.ingredients, this.directions, this.rating, this.imgUrl);
 
-  String toJsonString() {
-    Map data = {
-                "id" : id,
-                "name" : name,
-                "category" : category,
-                "ingredients" : ingredients,
-                "directions" : directions,
-                "rating" : rating,
-                "imgUrl" : imgUrl
-    };
-    return JSON.encode(data);
-  }
+  Map<String, dynamic> toJson() => <String, dynamic>{
+    "id": id,
+    "name": name,
+    "category": category,
+    "ingredients": ingredients,
+    "directions": directions,
+    "rating": rating,
+    "imgUrl": imgUrl
+  };
 
-  factory Recipe.fromJsonMap(Map json) {
-    return new Recipe(json['id'], json['name'], json['category'],
-        json['ingredients'], json['directions'], json['rating'],
-        json['imgUrl']);
-  }
+  factory Recipe.fromJsonMap(Map<String, dynamic> json) => new Recipe(json['id'], json['name'],
+      json['category'], json['ingredients'], json['directions'], json['rating'],
+      json['imgUrl']);
 }

--- a/Chapter_06/lib/service/recipe.dart
+++ b/Chapter_06/lib/service/recipe.dart
@@ -9,7 +9,8 @@ class Recipe {
   int rating;
   String imgUrl;
 
-  Recipe(this.id, this.name, this.category, this.ingredients, this.directions, this.rating, this.imgUrl);
+  Recipe(this.id, this.name, this.category, this.ingredients, this.directions,
+      this.rating, this.imgUrl);
 
   Map<String, dynamic> toJson() => <String, dynamic>{
     "id": id,

--- a/Chapter_06/lib/service/recipe.dart
+++ b/Chapter_06/lib/service/recipe.dart
@@ -22,7 +22,7 @@ class Recipe {
     "imgUrl": imgUrl
   };
 
-  factory Recipe.fromJsonMap(Map<String, dynamic> json) => new Recipe(json['id'], json['name'],
-      json['category'], json['ingredients'], json['directions'], json['rating'],
-      json['imgUrl']);
+  factory Recipe.fromJsonMap(Map<String, dynamic> json) => new Recipe(json['id'],
+      json['name'], json['category'], json['ingredients'], json['directions'],
+      json['rating'], json['imgUrl']);
 }

--- a/Chapter_06/lib/service/recipe.dart
+++ b/Chapter_06/lib/service/recipe.dart
@@ -1,7 +1,5 @@
 library recipe;
 
-import 'dart:convert';
-
 class Recipe {
   String id;
   String name;
@@ -11,25 +9,19 @@ class Recipe {
   int rating;
   String imgUrl;
 
-  Recipe(this.id, this.name, this.category, this.ingredients, this.directions,
-      this.rating, this.imgUrl);
+  Recipe(this.id, this.name, this.category, this.ingredients, this.directions, this.rating, this.imgUrl);
 
-  String toJsonString() {
-    Map data = {
-                "id" : id,
-                "name" : name,
-                "category" : category,
-                "ingredients" : ingredients,
-                "directions" : directions,
-                "rating" : rating,
-                "imgUrl" : imgUrl
-    };
-    return JSON.encode(data);
-  }
+  Map<String, dynamic> toJson() => <String, dynamic>{
+    "id": id,
+    "name": name,
+    "category": category,
+    "ingredients": ingredients,
+    "directions": directions,
+    "rating": rating,
+    "imgUrl": imgUrl
+  };
 
-  factory Recipe.fromJsonMap(Map json) {
-    return new Recipe(json['id'], json['name'], json['category'],
-        json['ingredients'], json['directions'], json['rating'],
-        json['imgUrl']);
-  }
+  factory Recipe.fromJsonMap(Map<String, dynamic> json) => new Recipe(json['id'], json['name'],
+      json['category'], json['ingredients'], json['directions'], json['rating'],
+      json['imgUrl']);
 }

--- a/Chapter_07/lib/service/recipe.dart
+++ b/Chapter_07/lib/service/recipe.dart
@@ -9,7 +9,8 @@ class Recipe {
   int rating;
   String imgUrl;
 
-  Recipe(this.id, this.name, this.category, this.ingredients, this.directions, this.rating, this.imgUrl);
+  Recipe(this.id, this.name, this.category, this.ingredients, this.directions,
+      this.rating, this.imgUrl);
 
   Map<String, dynamic> toJson() => <String, dynamic>{
     "id": id,

--- a/Chapter_07/lib/service/recipe.dart
+++ b/Chapter_07/lib/service/recipe.dart
@@ -22,7 +22,7 @@ class Recipe {
     "imgUrl": imgUrl
   };
 
-  factory Recipe.fromJsonMap(Map<String, dynamic> json) => new Recipe(json['id'], json['name'],
-      json['category'], json['ingredients'], json['directions'], json['rating'],
-      json['imgUrl']);
+  factory Recipe.fromJsonMap(Map<String, dynamic> json) => new Recipe(json['id'],
+      json['name'], json['category'], json['ingredients'], json['directions'],
+      json['rating'], json['imgUrl']);
 }

--- a/Chapter_07/lib/service/recipe.dart
+++ b/Chapter_07/lib/service/recipe.dart
@@ -1,7 +1,5 @@
 library recipe;
 
-import 'dart:convert';
-
 class Recipe {
   String id;
   String name;
@@ -11,25 +9,19 @@ class Recipe {
   int rating;
   String imgUrl;
 
-  Recipe(this.id, this.name, this.category, this.ingredients, this.directions,
-      this.rating, this.imgUrl);
+  Recipe(this.id, this.name, this.category, this.ingredients, this.directions, this.rating, this.imgUrl);
 
-  String toJsonString() {
-    Map data = {
-                "id" : id,
-                "name" : name,
-                "category" : category,
-                "ingredients" : ingredients,
-                "directions" : directions,
-                "rating" : rating,
-                "imgUrl" : imgUrl
-    };
-    return JSON.encode(data);
-  }
+  Map<String, dynamic> toJson() => <String, dynamic>{
+    "id": id,
+    "name": name,
+    "category": category,
+    "ingredients": ingredients,
+    "directions": directions,
+    "rating": rating,
+    "imgUrl": imgUrl
+  };
 
-  factory Recipe.fromJsonMap(Map json) {
-    return new Recipe(json['id'], json['name'], json['category'],
-        json['ingredients'], json['directions'], json['rating'],
-        json['imgUrl']);
-  }
+  factory Recipe.fromJsonMap(Map<String, dynamic> json) => new Recipe(json['id'], json['name'],
+      json['category'], json['ingredients'], json['directions'], json['rating'],
+      json['imgUrl']);
 }


### PR DESCRIPTION
- `recipe.dart` of Chap. 5:
  - Follow (new?) [dart:convert.JsonCodec#encode](https://api.dartlang.org/apidocs/channels/stable/#dart-convert.JsonCodec@id_encode) encoding convention and replace `String toJsonString()` by `Map toJson()`.
  - Some code cleanup.
- Chap. 6 & 7 made to match updates to Chap. 5.
