### PR TITLE
Update to Angular 0.9.10, and a few fixes

### DIFF
--- a/Chapter_01/pubspec.lock
+++ b/Chapter_01/pubspec.lock
@@ -4,19 +4,27 @@ packages:
   analyzer:
     description: analyzer
     source: hosted
-    version: "0.11.10"
+    version: "0.12.2"
   angular:
     description: angular
     source: hosted
-    version: "0.9.8"
+    version: "0.9.10"
   args:
     description: args
     source: hosted
-    version: "0.9.0"
+    version: "0.10.0+2"
+  barback:
+    description: barback
+    source: hosted
+    version: "0.11.1"
   browser:
     description: browser
     source: hosted
     version: "0.9.1"
+  code_transformers:
+    description: code_transformers
+    source: hosted
+    version: "0.0.1-dev.2"
   collection:
     description: collection
     source: hosted
@@ -24,23 +32,27 @@ packages:
   di:
     description: di
     source: hosted
-    version: "0.0.33"
+    version: "0.0.34"
   html5lib:
     description: html5lib
     source: hosted
-    version: "0.9.1"
+    version: "0.9.2"
   intl:
     description: intl
     source: hosted
-    version: "0.9.6"
+    version: "0.8.10+4"
   logging:
     description: logging
     source: hosted
     version: "0.9.1+1"
+  meta:
+    description: meta
+    source: hosted
+    version: "0.8.8"
   path:
     description: path
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0"
   perf_api:
     description: perf_api
     source: hosted
@@ -48,7 +60,7 @@ packages:
   route_hierarchical:
     description: route_hierarchical
     source: hosted
-    version: "0.4.14"
+    version: "0.4.15"
   shadow_dom:
     description: shadow_dom
     source: hosted
@@ -60,15 +72,11 @@ packages:
   stack_trace:
     description: stack_trace
     source: hosted
-    version: "0.9.2"
+    version: "0.9.3"
   unittest:
     description: unittest
     source: hosted
     version: "0.10.0"
-  unmodifiable_collection:
-    description: unmodifiable_collection
-    source: hosted
-    version: "0.9.2+1"
   utf:
     description: utf
     source: hosted

--- a/Chapter_03/pubspec.lock
+++ b/Chapter_03/pubspec.lock
@@ -4,19 +4,27 @@ packages:
   analyzer:
     description: analyzer
     source: hosted
-    version: "0.11.10"
+    version: "0.12.2"
   angular:
     description: angular
     source: hosted
-    version: "0.9.8"
+    version: "0.9.10"
   args:
     description: args
     source: hosted
-    version: "0.9.0"
+    version: "0.10.0+2"
+  barback:
+    description: barback
+    source: hosted
+    version: "0.11.1"
   browser:
     description: browser
     source: hosted
     version: "0.9.1"
+  code_transformers:
+    description: code_transformers
+    source: hosted
+    version: "0.0.1-dev.2"
   collection:
     description: collection
     source: hosted
@@ -24,15 +32,15 @@ packages:
   di:
     description: di
     source: hosted
-    version: "0.0.33"
+    version: "0.0.34"
   html5lib:
     description: html5lib
     source: hosted
-    version: "0.9.1"
+    version: "0.9.2"
   intl:
     description: intl
     source: hosted
-    version: "0.9.6"
+    version: "0.8.10+4"
   js:
     description: js
     source: hosted
@@ -41,10 +49,14 @@ packages:
     description: logging
     source: hosted
     version: "0.9.1+1"
+  meta:
+    description: meta
+    source: hosted
+    version: "0.8.8"
   path:
     description: path
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0"
   perf_api:
     description: perf_api
     source: hosted
@@ -52,7 +64,7 @@ packages:
   route_hierarchical:
     description: route_hierarchical
     source: hosted
-    version: "0.4.14"
+    version: "0.4.15"
   shadow_dom:
     description: shadow_dom
     source: hosted
@@ -64,15 +76,11 @@ packages:
   stack_trace:
     description: stack_trace
     source: hosted
-    version: "0.9.2"
+    version: "0.9.3"
   unittest:
     description: unittest
     source: hosted
     version: "0.10.0"
-  unmodifiable_collection:
-    description: unmodifiable_collection
-    source: hosted
-    version: "0.9.2+1"
   utf:
     description: utf
     source: hosted

--- a/Chapter_04/pubspec.lock
+++ b/Chapter_04/pubspec.lock
@@ -4,19 +4,27 @@ packages:
   analyzer:
     description: analyzer
     source: hosted
-    version: "0.11.10"
+    version: "0.12.2"
   angular:
     description: angular
     source: hosted
-    version: "0.9.8"
+    version: "0.9.10"
   args:
     description: args
     source: hosted
-    version: "0.9.0"
+    version: "0.10.0+2"
+  barback:
+    description: barback
+    source: hosted
+    version: "0.11.1"
   browser:
     description: browser
     source: hosted
     version: "0.9.1"
+  code_transformers:
+    description: code_transformers
+    source: hosted
+    version: "0.0.1-dev.2"
   collection:
     description: collection
     source: hosted
@@ -24,15 +32,15 @@ packages:
   di:
     description: di
     source: hosted
-    version: "0.0.33"
+    version: "0.0.34"
   html5lib:
     description: html5lib
     source: hosted
-    version: "0.9.1"
+    version: "0.9.2"
   intl:
     description: intl
     source: hosted
-    version: "0.9.6"
+    version: "0.8.10+4"
   js:
     description: js
     source: hosted
@@ -41,10 +49,14 @@ packages:
     description: logging
     source: hosted
     version: "0.9.1+1"
+  meta:
+    description: meta
+    source: hosted
+    version: "0.8.8"
   path:
     description: path
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0"
   perf_api:
     description: perf_api
     source: hosted
@@ -52,7 +64,7 @@ packages:
   route_hierarchical:
     description: route_hierarchical
     source: hosted
-    version: "0.4.14"
+    version: "0.4.15"
   shadow_dom:
     description: shadow_dom
     source: hosted
@@ -64,15 +76,11 @@ packages:
   stack_trace:
     description: stack_trace
     source: hosted
-    version: "0.9.2"
+    version: "0.9.3"
   unittest:
     description: unittest
     source: hosted
     version: "0.10.0"
-  unmodifiable_collection:
-    description: unmodifiable_collection
-    source: hosted
-    version: "0.9.2+1"
   utf:
     description: utf
     source: hosted

--- a/Chapter_05/pubspec.lock
+++ b/Chapter_05/pubspec.lock
@@ -4,19 +4,27 @@ packages:
   analyzer:
     description: analyzer
     source: hosted
-    version: "0.11.10"
+    version: "0.12.2"
   angular:
     description: angular
     source: hosted
-    version: "0.9.8"
+    version: "0.9.10"
   args:
     description: args
     source: hosted
-    version: "0.9.0"
+    version: "0.10.0+2"
+  barback:
+    description: barback
+    source: hosted
+    version: "0.11.1"
   browser:
     description: browser
     source: hosted
     version: "0.9.1"
+  code_transformers:
+    description: code_transformers
+    source: hosted
+    version: "0.0.1-dev.2"
   collection:
     description: collection
     source: hosted
@@ -24,15 +32,15 @@ packages:
   di:
     description: di
     source: hosted
-    version: "0.0.33"
+    version: "0.0.34"
   html5lib:
     description: html5lib
     source: hosted
-    version: "0.9.1"
+    version: "0.9.2"
   intl:
     description: intl
     source: hosted
-    version: "0.9.6"
+    version: "0.8.10+4"
   js:
     description: js
     source: hosted
@@ -41,10 +49,14 @@ packages:
     description: logging
     source: hosted
     version: "0.9.1+1"
+  meta:
+    description: meta
+    source: hosted
+    version: "0.8.8"
   path:
     description: path
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0"
   perf_api:
     description: perf_api
     source: hosted
@@ -52,7 +64,7 @@ packages:
   route_hierarchical:
     description: route_hierarchical
     source: hosted
-    version: "0.4.14"
+    version: "0.4.15"
   shadow_dom:
     description: shadow_dom
     source: hosted
@@ -64,15 +76,11 @@ packages:
   stack_trace:
     description: stack_trace
     source: hosted
-    version: "0.9.2"
+    version: "0.9.3"
   unittest:
     description: unittest
     source: hosted
     version: "0.10.0"
-  unmodifiable_collection:
-    description: unmodifiable_collection
-    source: hosted
-    version: "0.9.2+1"
   utf:
     description: utf
     source: hosted

--- a/Chapter_06/lib/component/view_recipe_component.dart
+++ b/Chapter_06/lib/component/view_recipe_component.dart
@@ -9,12 +9,12 @@ import 'package:angular/angular.dart';
     cssUrl: 'packages/angular_dart_demo/component/view_recipe_component.css',
     publishAs: 'cmp')
 class ViewRecipeComponent {
-  @NgTwoWay('recipe-map')
+  @NgOneWay('recipe-map')
   Map<String, Recipe> recipeMap;
 
   String _recipeId;
 
-  Recipe get recipe => recipeMap[_recipeId];
+  Recipe get recipe => recipeMap == null ? null : recipeMap[_recipeId];
 
   ViewRecipeComponent(RouteProvider routeProvider) {
     _recipeId = routeProvider.parameters['recipeId'];

--- a/Chapter_06/lib/routing/recipe_book_router.dart
+++ b/Chapter_06/lib/routing/recipe_book_router.dart
@@ -2,7 +2,7 @@ library recipe_book_routing;
 
 import 'package:angular/angular.dart';
 
-void recipeBookRouteInitializer(Router router, ViewFactory views) {
+void recipeBookRouteInitializer(Router router, RouteViewFactory views) {
   views.configure({
     'add': ngRoute(
         path: '/add',
@@ -20,7 +20,7 @@ void recipeBookRouteInitializer(Router router, ViewFactory views) {
               defaultRoute: true,
               enter: (RouteEnterEvent e) =>
                   router.go('view', {},
-                      startingFrom: router.root.getRoute('recipe'),
+                      startingFrom: router.root.findRoute('recipe'),
                       replace: true))
         })
   });

--- a/Chapter_06/pubspec.lock
+++ b/Chapter_06/pubspec.lock
@@ -4,19 +4,27 @@ packages:
   analyzer:
     description: analyzer
     source: hosted
-    version: "0.11.10"
+    version: "0.12.2"
   angular:
     description: angular
     source: hosted
-    version: "0.9.8"
+    version: "0.9.10"
   args:
     description: args
     source: hosted
-    version: "0.9.0"
+    version: "0.10.0+2"
+  barback:
+    description: barback
+    source: hosted
+    version: "0.11.1"
   browser:
     description: browser
     source: hosted
     version: "0.9.1"
+  code_transformers:
+    description: code_transformers
+    source: hosted
+    version: "0.0.1-dev.2"
   collection:
     description: collection
     source: hosted
@@ -24,11 +32,11 @@ packages:
   di:
     description: di
     source: hosted
-    version: "0.0.33"
+    version: "0.0.34"
   html5lib:
     description: html5lib
     source: hosted
-    version: "0.9.1"
+    version: "0.9.2"
   http_server:
     description: http_server
     source: hosted
@@ -36,7 +44,7 @@ packages:
   intl:
     description: intl
     source: hosted
-    version: "0.9.6"
+    version: "0.8.10+4"
   js:
     description: js
     source: hosted
@@ -45,6 +53,10 @@ packages:
     description: logging
     source: hosted
     version: "0.9.1+1"
+  meta:
+    description: meta
+    source: hosted
+    version: "0.8.8"
   mime:
     description: mime
     source: hosted
@@ -52,7 +64,7 @@ packages:
   path:
     description: path
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0"
   perf_api:
     description: perf_api
     source: hosted
@@ -60,7 +72,7 @@ packages:
   route_hierarchical:
     description: route_hierarchical
     source: hosted
-    version: "0.4.14"
+    version: "0.4.15"
   shadow_dom:
     description: shadow_dom
     source: hosted
@@ -72,15 +84,11 @@ packages:
   stack_trace:
     description: stack_trace
     source: hosted
-    version: "0.9.2"
+    version: "0.9.3"
   unittest:
     description: unittest
     source: hosted
     version: "0.10.0"
-  unmodifiable_collection:
-    description: unmodifiable_collection
-    source: hosted
-    version: "0.9.2+1"
   utf:
     description: utf
     source: hosted

--- a/Chapter_07/lib/component/view_recipe_component.dart
+++ b/Chapter_07/lib/component/view_recipe_component.dart
@@ -9,12 +9,12 @@ import 'package:angular/angular.dart';
     cssUrl: 'packages/angular_dart_demo/component/view_recipe_component.css',
     publishAs: 'cmp')
 class ViewRecipeComponent {
-  @NgTwoWay('recipe-map')
+  @NgOneWay('recipe-map')
   Map<String, Recipe> recipeMap;
 
   String _recipeId;
 
-  Recipe get recipe => recipeMap[_recipeId];
+  Recipe get recipe => recipeMap == null ? null : recipeMap[_recipeId];
 
   ViewRecipeComponent(RouteProvider routeProvider) {
     _recipeId = routeProvider.parameters['recipeId'];

--- a/Chapter_07/lib/routing/recipe_book_router.dart
+++ b/Chapter_07/lib/routing/recipe_book_router.dart
@@ -2,7 +2,7 @@ library recipe_book_routing;
 
 import 'package:angular/angular.dart';
 
-void recipeBookRouteInitializer(Router router, ViewFactory views) {
+void recipeBookRouteInitializer(Router router, RouteViewFactory views) {
   views.configure({
     'add': ngRoute(
         path: '/add',
@@ -20,7 +20,7 @@ void recipeBookRouteInitializer(Router router, ViewFactory views) {
               defaultRoute: true,
               enter: (RouteEnterEvent e) =>
                   router.go('view', {},
-                      startingFrom: router.root.getRoute('recipe'),
+                      startingFrom: router.root.findRoute('recipe'),
                       replace: true))
         })
   });

--- a/Chapter_07/pubspec.lock
+++ b/Chapter_07/pubspec.lock
@@ -4,19 +4,27 @@ packages:
   analyzer:
     description: analyzer
     source: hosted
-    version: "0.11.10"
+    version: "0.12.2"
   angular:
     description: angular
     source: hosted
-    version: "0.9.8"
+    version: "0.9.10"
   args:
     description: args
     source: hosted
-    version: "0.9.0"
+    version: "0.10.0+2"
+  barback:
+    description: barback
+    source: hosted
+    version: "0.11.1"
   browser:
     description: browser
     source: hosted
     version: "0.9.1"
+  code_transformers:
+    description: code_transformers
+    source: hosted
+    version: "0.0.1-dev.2"
   collection:
     description: collection
     source: hosted
@@ -24,15 +32,15 @@ packages:
   di:
     description: di
     source: hosted
-    version: "0.0.33"
+    version: "0.0.34"
   html5lib:
     description: html5lib
     source: hosted
-    version: "0.9.1"
+    version: "0.9.2"
   intl:
     description: intl
     source: hosted
-    version: "0.9.6"
+    version: "0.8.10+4"
   js:
     description: js
     source: hosted
@@ -41,10 +49,14 @@ packages:
     description: logging
     source: hosted
     version: "0.9.1+1"
+  meta:
+    description: meta
+    source: hosted
+    version: "0.8.8"
   path:
     description: path
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0"
   perf_api:
     description: perf_api
     source: hosted
@@ -52,7 +64,7 @@ packages:
   route_hierarchical:
     description: route_hierarchical
     source: hosted
-    version: "0.4.14"
+    version: "0.4.15"
   shadow_dom:
     description: shadow_dom
     source: hosted
@@ -64,15 +76,11 @@ packages:
   stack_trace:
     description: stack_trace
     source: hosted
-    version: "0.9.2"
+    version: "0.9.3"
   unittest:
     description: unittest
     source: hosted
     version: "0.10.0"
-  unmodifiable_collection:
-    description: unmodifiable_collection
-    source: hosted
-    version: "0.9.2+1"
   utf:
     description: utf
     source: hosted


### PR DESCRIPTION
- `pubspec.lock` updated, in particular to Angular 0.9.10.
- Renamed a type in route (to match rename made in Angular).
- `ViewRecipeComponent.recipeMap` declared `@NgOneWay` (since it doesn’t change the map).
- `ViewRecipeComponent.recipe` now handles null maps.
