### PR TITLE
Fix angular/angular.dart.tutorial#132

### DIFF
--- a/Chapter_05/lib/component/recipe_book.dart
+++ b/Chapter_05/lib/component/recipe_book.dart
@@ -82,6 +82,7 @@ class RecipeBookComponent {
         for (String category in response.data) {
           categoryFilterMap[category] = false;
         }
+        categories.clear();
         categories.addAll(categoryFilterMap.keys);
         categoriesLoaded = true;
       })

--- a/Chapter_06/lib/component/search_recipe.dart
+++ b/Chapter_06/lib/component/search_recipe.dart
@@ -7,8 +7,8 @@ import 'package:angular/angular.dart';
     templateUrl: 'search_recipe.html')
 class SearchRecipeComponent {
   Map<String, bool> _categoryFilterMap = {};
-  List<String> _categories = [];
-  List<String> get categories => _categories;
+  final List<String> categories = [];
+
 
   @NgTwoWay('name-filter-string')
   String nameFilterString = "";
@@ -17,7 +17,8 @@ class SearchRecipeComponent {
   Map<String, bool> get categoryFilterMap => _categoryFilterMap;
   void set categoryFilterMap(values) {
     _categoryFilterMap = values;
-    _categories.addAll(categoryFilterMap.keys);
+    categories.clear();
+    categories.addAll(categoryFilterMap.keys);
   }
 
   void clearFilters() {


### PR DESCRIPTION
Use final fields instead of private fields with public getters.
To avoid a potential bug, in set categoryFilterMap(values) the categories
list probably needs to be cleared before addAll is called.