### PR TITLE
Make it clear that this is for AngularDart 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-This repo contains the examples from the [AngularDart Tutorial][tut].
+This repo contains the examples from the [AngularDart 1 Tutorial][tut]. You may want to check out the newer [AngularDart][angulardart] (a.k.a. Angular 2 for Dart) and its [tutorial][tut2] instead.
 
-[tut]: https://angulardart.org/tutorial/
-
+[angulardart]: https://webdev.dartlang.org/angular
+[tut]: https://web.archive.org/web/20160304145052/https://angulardart.org/tutorial/
+[tut2]: https://webdev.dartlang.org/angular/tutorial


### PR DESCRIPTION
Also, update the link so it doesn't redirect to webdev.dartlang.org/angular (which is confusing).